### PR TITLE
DD-2565 introduce sessionId and handle same domain requests

### DIFF
--- a/SPDiagnose.xcodeproj/project.pbxproj
+++ b/SPDiagnose.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		82C5AEDE2BA3491400850FC9 /* SPDiagnose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829EBC6A2BA344190063F156 /* SPDiagnose.swift */; };
 		82D9691C2C622EA80073790F /* SPHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D9691B2C622EA80073790F /* SPHttpClient.swift */; };
 		82D9691E2C64C7440073790F /* NetworkLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D9691D2C64C7440073790F /* NetworkLoggerTests.swift */; };
+		82D969202C64CD890073790F /* NetworkSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D9691F2C64CD890073790F /* NetworkSubscriberTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +91,7 @@
 		829EBC922BA3444A0063F156 /* SPDiagnoseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPDiagnoseTests.swift; sourceTree = "<group>"; };
 		82D9691B2C622EA80073790F /* SPHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPHttpClient.swift; sourceTree = "<group>"; };
 		82D9691D2C64C7440073790F /* NetworkLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLoggerTests.swift; sourceTree = "<group>"; };
+		82D9691F2C64CD890073790F /* NetworkSubscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSubscriberTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -207,6 +209,7 @@
 			children = (
 				829EBC922BA3444A0063F156 /* SPDiagnoseTests.swift */,
 				82D9691D2C64C7440073790F /* NetworkLoggerTests.swift */,
+				82D9691F2C64CD890073790F /* NetworkSubscriberTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -385,6 +388,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				829EBC952BA3447E0063F156 /* SPDiagnoseTests.swift in Sources */,
+				82D969202C64CD890073790F /* NetworkSubscriberTests.swift in Sources */,
 				82D9691E2C64C7440073790F /* NetworkLoggerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SPDiagnose.xcodeproj/project.pbxproj
+++ b/SPDiagnose.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		82C5AEDD2BA3490C00850FC9 /* SPDiagnose+AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829EBC642BA344190063F156 /* SPDiagnose+AppDelegate.swift */; };
 		82C5AEDE2BA3491400850FC9 /* SPDiagnose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829EBC6A2BA344190063F156 /* SPDiagnose.swift */; };
 		82D9691C2C622EA80073790F /* SPHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D9691B2C622EA80073790F /* SPHttpClient.swift */; };
+		82D9691E2C64C7440073790F /* NetworkLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D9691D2C64C7440073790F /* NetworkLoggerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		829EBC6A2BA344190063F156 /* SPDiagnose.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPDiagnose.swift; sourceTree = "<group>"; };
 		829EBC922BA3444A0063F156 /* SPDiagnoseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SPDiagnoseTests.swift; sourceTree = "<group>"; };
 		82D9691B2C622EA80073790F /* SPHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPHttpClient.swift; sourceTree = "<group>"; };
+		82D9691D2C64C7440073790F /* NetworkLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLoggerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -204,6 +206,7 @@
 			isa = PBXGroup;
 			children = (
 				829EBC922BA3444A0063F156 /* SPDiagnoseTests.swift */,
+				82D9691D2C64C7440073790F /* NetworkLoggerTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -382,6 +385,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				829EBC952BA3447E0063F156 /* SPDiagnoseTests.swift in Sources */,
+				82D9691E2C64C7440073790F /* NetworkLoggerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/SPDiagnose+AppDelegate.swift
+++ b/Sources/SPDiagnose+AppDelegate.swift
@@ -9,10 +9,5 @@ import Foundation
 import UIKit
 
 public class SPDiagnoseAppDelegate: NSObject, UIApplicationDelegate {
-    public var diagnose: SPDiagnose?
-
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        diagnose = SPDiagnose()
-        return true
-    }
+    public var diagnose: SPDiagnose = SPDiagnose()
 }

--- a/Sources/SPDiagnose.swift
+++ b/Sources/SPDiagnose.swift
@@ -37,13 +37,9 @@ extension SPDiagnose {
         }
     }
 
-    @objcMembers class NetworkLogger: URLProtocol {
-        static var domains = Set<String>()
-
-        override class func canInit(with request: URLRequest) -> Bool {
-            if let domain = request.url?.host, !domains.contains(domain) {
-                domains.insert(domain)
-
+    @objcMembers public class NetworkLogger: URLProtocol {
+        override class public func canInit(with request: URLRequest) -> Bool {
+            if let domain = request.url?.host {
                 SPLogger.log("Request captured: \(domain)")
 
                 NotificationCenter.default.post(
@@ -52,7 +48,12 @@ extension SPDiagnose {
                     userInfo: ["domain": domain]
                 )
             }
+            return false
+        }
 
+        /// we need to override `canInit(with task:)` otherwise `canInit(with request:)`
+        /// gets called multiple times
+        public override class func canInit(with task: URLSessionTask) -> Bool {
             return false
         }
     }

--- a/Sources/SPDiagnose.swift
+++ b/Sources/SPDiagnose.swift
@@ -118,13 +118,14 @@ extension SPDiagnose {
         self.api = dApi
         self.networkSubscriber = NetworkSubscriber { domain in
             Task {
-                // TODO: filter out our own network calls
-                await dApi.sendEvent(
-                    .network(
-                        domain: domain,
-                        tcString: UserDefaults.standard.string(forKey: "IABTCF_TCString")
+                if (domain != SPDiagnoseAPI.baseUrl.host) {
+                    await dApi.sendEvent(
+                        .network(
+                            domain: domain,
+                            tcString: UserDefaults.standard.string(forKey: "IABTCF_TCString")
+                        )
                     )
-                )
+                }
             }
         }
     }

--- a/Sources/api/SPDiagnoseAPI.swift
+++ b/Sources/api/SPDiagnoseAPI.swift
@@ -61,8 +61,8 @@ struct SendEventResponse: Decodable {}
     var client: HttpClient
     var logger: SPLogger.Type?
 
-    var baseUrl: URL { URL(string: "https://compliance-api.sp-redbud.com")! }
-    var eventsUrl: URL { URL(string: "/recordEvents/?_version=1.0.70", relativeTo: baseUrl)! }
+    public static var baseUrl: URL { URL(string: "https://compliance-api.sp-redbud.com")! }
+    static var eventsUrl: URL { URL(string: "/recordEvents/?_version=1.0.70", relativeTo: baseUrl)! }
 
     init(
         accountId: Int,
@@ -111,7 +111,7 @@ struct SendEventResponse: Decodable {}
                     )
             }
             let _: SendEventResponse? = try await client.put(
-                eventsUrl,
+                Self.eventsUrl,
                 body: SendEventRequest(
                     accountId: accountId,
                     propertyId: propertyId,

--- a/Sources/api/SPDiagnoseAPI.swift
+++ b/Sources/api/SPDiagnoseAPI.swift
@@ -48,6 +48,7 @@ struct SendEventRequest: Encodable {
     let accountId, propertyId: Int
     let appName: String?
     let events: [Event]
+    let sessionId: UUID
 }
 
 struct SendEventResponse: Decodable {}
@@ -55,6 +56,7 @@ struct SendEventResponse: Decodable {}
 @objcMembers class SPDiagnoseAPI: NSObject {
     let accountId, propertyId: Int
     let appName: String?
+    lazy var sessionId = UUID()
 
     var client: HttpClient
     var logger: SPLogger.Type?
@@ -114,7 +116,8 @@ struct SendEventResponse: Decodable {}
                     accountId: accountId,
                     propertyId: propertyId,
                     appName: appName,
-                    events: events
+                    events: events,
+                    sessionId: sessionId
                 )
             )
         } catch {

--- a/Tests/NetworkLoggerTests.swift
+++ b/Tests/NetworkLoggerTests.swift
@@ -1,0 +1,53 @@
+//
+//  NetworkLoggerTests.swift
+//  SPDiagnoseTests
+//
+//  Created by Andre Herculano on 8/8/24.
+//
+
+import Foundation
+
+import XCTest
+@testable import SPDiagnose
+
+class NetworkLoggerTests: XCTestCase {
+    override func setUpWithError() throws {
+        URLSessionConfiguration.default.protocolClasses?.append(SPDiagnose.NetworkLogger.self)
+    }
+
+    override func tearDownWithError() throws {}
+
+    func request(_ domain: String) {
+        URLSession(configuration: .default)
+            .dataTask(
+                with: URLRequest(url: URL(string: "https://\(domain)")!)
+            )
+            .resume()
+    }
+
+    func observeNotificationCenter(handler: @escaping (Notification) -> Void) {
+        NotificationCenter.default.addObserver(
+            forName: .SPDiagnoseNetworkIntercepted,
+            object: nil,
+            queue: OperationQueue.main,
+            using: handler
+        )
+    }
+
+    func testItPostsToNotificationCenterOnEachNetworkRequest() throws {
+        let domain = "sourcepoint.com"
+        let expectation = XCTestExpectation(description: "NotificationCenter notified")
+        observeNotificationCenter {
+            let notifiedDomain = $0.userInfo?["domain"] as? String
+            if (notifiedDomain == domain) {
+                expectation.fulfill()
+            } else {
+                XCTFail("notification was posted but with a different domain: \(notifiedDomain as Any)")
+            }
+        }
+
+        request(domain)
+        wait(for: [expectation], timeout: 5)
+    }
+}
+

--- a/Tests/NetworkSubscriberTests.swift
+++ b/Tests/NetworkSubscriberTests.swift
@@ -1,0 +1,39 @@
+//
+//  NetworkSubscriberTests.swift
+//  SPDiagnoseTests
+//
+//  Created by Andre Herculano on 8/8/24.
+//
+
+import Foundation
+import XCTest
+@testable import SPDiagnose
+
+class NetworkSubscriberTests: XCTestCase {
+    func postNotificationCenter(_ domain: String) {
+        NotificationCenter.default.post(
+            name: .SPDiagnoseNetworkIntercepted,
+            object: nil,
+            userInfo: ["domain": domain]
+        )
+    }
+
+    func testItCallsOnNotification() {
+        let expectation = XCTestExpectation(description: "Notification intercepted")
+        let domain = "foo"
+
+        /// even though XCode warns about `subscriber` not being used
+        /// if replaced with `_` XCode will release the NetworkSubscriber
+        /// causing the test to fail ¯\_(ツ)_/¯
+        let subscriber = SPDiagnose.NetworkSubscriber { receivedDomain in
+            if (receivedDomain == domain) {
+                expectation.fulfill()
+            } else {
+                XCTFail("notification intercepted but with a different domain: \(receivedDomain as Any)")
+            }
+        }
+        postNotificationCenter(domain)
+        wait(for: [expectation], timeout: 5)
+    }
+}
+

--- a/iOSExample/iOSExampleApp.swift
+++ b/iOSExample/iOSExampleApp.swift
@@ -16,10 +16,10 @@ struct iOSExampleApp: App {
         WindowGroup {
             ContentView(
                 acceptAll: {
-                    Task { await appDelegate.diagnose?.consentEvent(action: .acceptAll) }
+                    Task { await appDelegate.diagnose.consentEvent(action: .acceptAll) }
                 },
                 rejectAll: {
-                    Task { await appDelegate.diagnose?.consentEvent(action: .rejectAll) }
+                    Task { await appDelegate.diagnose.consentEvent(action: .rejectAll) }
                 }
             )
         }


### PR DESCRIPTION
* introduce sessionId in order to differentiate vendors being called within the same session
* remove the restriction that was logging network request only the first time for each domain