### PR TITLE
DIA-2645 implement sampling

### DIFF
--- a/SPDiagnose.xcodeproj/project.pbxproj
+++ b/SPDiagnose.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		82D9691C2C622EA80073790F /* SPHttpClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D9691B2C622EA80073790F /* SPHttpClient.swift */; };
 		82D9691E2C64C7440073790F /* NetworkLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D9691D2C64C7440073790F /* NetworkLoggerTests.swift */; };
 		82D969202C64CD890073790F /* NetworkSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D9691F2C64CD890073790F /* NetworkSubscriberTests.swift */; };
+		82D969222C64D86C0073790F /* Diagnose+Sampling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D969212C64D86C0073790F /* Diagnose+Sampling.swift */; };
+		82D969252C64D9AD0073790F /* SamplingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D969232C64D9710073790F /* SamplingTests.swift */; };
+		82D969272C6616AE0073790F /* UserDefaults+SPDiagnose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D969262C6616AE0073790F /* UserDefaults+SPDiagnose.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -92,6 +95,9 @@
 		82D9691B2C622EA80073790F /* SPHttpClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPHttpClient.swift; sourceTree = "<group>"; };
 		82D9691D2C64C7440073790F /* NetworkLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLoggerTests.swift; sourceTree = "<group>"; };
 		82D9691F2C64CD890073790F /* NetworkSubscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSubscriberTests.swift; sourceTree = "<group>"; };
+		82D969212C64D86C0073790F /* Diagnose+Sampling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diagnose+Sampling.swift"; sourceTree = "<group>"; };
+		82D969232C64D9710073790F /* SamplingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplingTests.swift; sourceTree = "<group>"; };
+		82D969262C6616AE0073790F /* UserDefaults+SPDiagnose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+SPDiagnose.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -200,6 +206,8 @@
 				8205F2212BA4A59800A47D82 /* objc */,
 				829EBC642BA344190063F156 /* SPDiagnose+AppDelegate.swift */,
 				829EBC6A2BA344190063F156 /* SPDiagnose.swift */,
+				82D969212C64D86C0073790F /* Diagnose+Sampling.swift */,
+				82D969262C6616AE0073790F /* UserDefaults+SPDiagnose.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -210,6 +218,7 @@
 				829EBC922BA3444A0063F156 /* SPDiagnoseTests.swift */,
 				82D9691D2C64C7440073790F /* NetworkLoggerTests.swift */,
 				82D9691F2C64CD890073790F /* NetworkSubscriberTests.swift */,
+				82D969232C64D9710073790F /* SamplingTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -374,11 +383,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				8205F22C2BA4A59800A47D82 /* SPDiagnoseSwizzler.m in Sources */,
+				82D969272C6616AE0073790F /* UserDefaults+SPDiagnose.swift in Sources */,
 				8205F22F2BA4A59800A47D82 /* SPDiagnoseAPI.swift in Sources */,
 				82C5AEDD2BA3490C00850FC9 /* SPDiagnose+AppDelegate.swift in Sources */,
 				8205F22E2BA4A59800A47D82 /* SPLogger.swift in Sources */,
 				82D9691C2C622EA80073790F /* SPHttpClient.swift in Sources */,
 				82C5AEDE2BA3491400850FC9 /* SPDiagnose.swift in Sources */,
+				82D969222C64D86C0073790F /* Diagnose+Sampling.swift in Sources */,
 				8205F22D2BA4A59800A47D82 /* SPConfig.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -387,6 +398,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				82D969252C64D9AD0073790F /* SamplingTests.swift in Sources */,
 				829EBC952BA3447E0063F156 /* SPDiagnoseTests.swift in Sources */,
 				82D969202C64CD890073790F /* NetworkSubscriberTests.swift in Sources */,
 				82D9691E2C64C7440073790F /* NetworkLoggerTests.swift in Sources */,

--- a/SPDiagnose.xcodeproj/xcshareddata/xcschemes/iOSExample.xcscheme
+++ b/SPDiagnose.xcodeproj/xcshareddata/xcschemes/iOSExample.xcscheme
@@ -26,8 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/iOSExample.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/SPDiagnoseWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/SPDiagnoseWorkspace.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:/Users/andreherculano/dev/sourcepoint/diagnose-sdk/SPDiagnose.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Tests/iOSExample.xctestplan">
+   </FileRef>
 </Workspace>

--- a/Sources/Diagnose+Sampling.swift
+++ b/Sources/Diagnose+Sampling.swift
@@ -1,0 +1,39 @@
+//
+//  Diagnose+Sampling.swift
+//  SPDiagnose
+//
+//  Created by Andre Herculano on 8/8/24.
+//
+
+import Foundation
+
+extension SPDiagnose {
+    struct Sampling {
+        static let shared = Sampling()
+
+        let storage = UserDefaults.standard
+
+        public enum StoreKeys: String {
+            case rate = "sp.diagnose.sampling.rate"
+            case hit = "sp.diagnose.sampling.hit"
+        }
+
+        private init() {}
+
+        var rate: Int {
+            get { storage.integer(forKey: StoreKeys.rate.rawValue) }
+        }
+        var hit: Bool? {
+            get { storage.boolOrNil(forKey: StoreKeys.hit.rawValue) }
+        }
+
+        func setRate(_ newValue: Int){
+            storage.set(newValue, forKey: StoreKeys.rate.rawValue)
+        }
+
+        func setHit(_ newValue: Bool?) {
+            storage.set(newValue, forKey: StoreKeys.hit.rawValue)
+        }
+    }
+}
+

--- a/Sources/Diagnose+Sampling.swift
+++ b/Sources/Diagnose+Sampling.swift
@@ -11,6 +11,13 @@ extension SPDiagnose {
     struct Sampling {
         static let shared = Sampling()
 
+        /// pick a random number from 0 to 100 if the number picked is smaller than `rate`
+        /// return `true` otherwise
+        /// return `false`
+        static func sampleIt(rate: Int) -> Bool {
+            return 0...Int(rate) ~= Int.random(in: 0...100)
+        }
+
         let storage = UserDefaults.standard
 
         public enum StoreKeys: String {
@@ -33,6 +40,14 @@ extension SPDiagnose {
 
         func setHit(_ newValue: Bool?) {
             storage.set(newValue, forKey: StoreKeys.hit.rawValue)
+        }
+
+        func updateAndSample(newRate: Int) -> Bool? {
+            if newRate != rate {
+                setRate(newRate)
+                setHit(Self.sampleIt(rate: newRate))
+            }
+            return hit
         }
     }
 }

--- a/Sources/SPDiagnose.swift
+++ b/Sources/SPDiagnose.swift
@@ -142,6 +142,8 @@ extension SPDiagnose {
     }
 
     public func consentEvent(action: SPDiagnose.ConsentAction) async {
-        await api.sendEvent(.consent(action: action))
+        if Sampling.shared.hit == true {
+            await api.sendEvent(.consent(action: action))
+        }
     }
 }

--- a/Sources/UserDefaults+SPDiagnose.swift
+++ b/Sources/UserDefaults+SPDiagnose.swift
@@ -1,0 +1,16 @@
+//
+//  UserDefaults+SPDiagnose.swift
+//  SPDiagnose
+//
+//  Created by Andre Herculano on 9/8/24.
+//
+
+import Foundation
+
+extension UserDefaults {
+    func boolOrNil(forKey defaultName: String) -> Bool? {
+        dictionaryRepresentation().keys.contains(defaultName) ?
+            bool(forKey: defaultName) :
+            nil
+    }
+}

--- a/Sources/api/SPDiagnoseAPI.swift
+++ b/Sources/api/SPDiagnoseAPI.swift
@@ -121,7 +121,7 @@ struct SendEventResponse: Decodable {}
                 )
             )
         } catch {
-            logger?.log("failed to sendEvent: \( error.localizedDescription)")
+            logger?.log("failed to sendEvent: \(error.localizedDescription)")
         }
     }
 }

--- a/Sources/api/SPDiagnoseAPI.swift
+++ b/Sources/api/SPDiagnoseAPI.swift
@@ -53,6 +53,10 @@ struct SendEventRequest: Encodable {
 
 struct SendEventResponse: Decodable {}
 
+struct GetMetaDataResponse: Decodable {
+    let samplingRate: Int
+}
+
 @objcMembers class SPDiagnoseAPI: NSObject {
     let accountId, propertyId: Int
     let appName: String?
@@ -63,6 +67,15 @@ struct SendEventResponse: Decodable {}
 
     public static var baseUrl: URL { URL(string: "https://compliance-api.sp-redbud.com")! }
     static var eventsUrl: URL { URL(string: "/recordEvents/?_version=1.0.70", relativeTo: baseUrl)! }
+    static var metaDataBaseUrl: URL { URL(string: "/meta-data/?_version=1.0.70", relativeTo: baseUrl)! }
+
+    var metaDataUrl: URL {
+        Self.metaDataBaseUrl.appending(params: [
+            "accountId": String(accountId),
+            "propertyId": String(propertyId),
+            "appName": appName
+        ])!
+    }
 
     init(
         accountId: Int,
@@ -123,5 +136,24 @@ struct SendEventResponse: Decodable {}
         } catch {
             logger?.log("failed to sendEvent: \(error.localizedDescription)")
         }
+    }
+
+    func getMetaData() async throws -> GetMetaDataResponse {
+        do {
+            return try await client.get(metaDataUrl)
+        } catch {
+            SPLogger.log("failed to getMetaData: \(error.localizedDescription)")
+            throw error
+        }
+    }
+}
+
+extension URL {
+    func appending(params: [String: String?]) -> URL? {
+        var components = URLComponents(url: self, resolvingAgainstBaseURL: true)
+        params.forEach {
+            components?.queryItems?.append(URLQueryItem(name: $0.key, value: $0.value))
+        }
+        return components?.url
     }
 }

--- a/Sources/api/SPHttpClient.swift
+++ b/Sources/api/SPHttpClient.swift
@@ -61,6 +61,10 @@ class SPHttpClient: HttpClient {
     func get<Response: Decodable>(_ url: URL) async throws -> Response {
         logger.log("request - GET \(url.absoluteString)")
 
+        // TODO: remove when /meta-data is implemented
+        if url.absoluteString.contains("meta-data") {
+            return GetMetaDataResponse(samplingRate: 21) as! Response
+        }
 
         return try parseResponse(
             try await URLSession.shared.data(for: URLRequest(url: url, bearer: auth))

--- a/Sources/api/SPHttpClient.swift
+++ b/Sources/api/SPHttpClient.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol HttpClient {
     init(auth: String, logger: SPLogger.Type)
     func put<Body: Encodable, Response: Decodable>(_ url: URL, body: Body) async throws -> Response
+    func get<Response: Decodable>(_ url: URL) async throws -> Response
 }
 
 class SPHttpClient: HttpClient {
@@ -56,7 +57,17 @@ class SPHttpClient: HttpClient {
             )
         )
     }
+
+    func get<Response: Decodable>(_ url: URL) async throws -> Response {
+        logger.log("request - GET \(url.absoluteString)")
+
+
+        return try parseResponse(
+            try await URLSession.shared.data(for: URLRequest(url: url, bearer: auth))
+        )
+    }
 }
+
 extension URLRequest {
     init(url: URL, method: String = "GET", bearer: String, body: Data? = nil) {
         self.init(url: url)

--- a/Tests/NetworkLoggerTests.swift
+++ b/Tests/NetworkLoggerTests.swift
@@ -41,8 +41,6 @@ class NetworkLoggerTests: XCTestCase {
             let notifiedDomain = $0.userInfo?["domain"] as? String
             if (notifiedDomain == domain) {
                 expectation.fulfill()
-            } else {
-                XCTFail("notification was posted but with a different domain: \(notifiedDomain as Any)")
             }
         }
 

--- a/Tests/NetworkLoggerTests.swift
+++ b/Tests/NetworkLoggerTests.swift
@@ -39,7 +39,7 @@ class NetworkLoggerTests: XCTestCase {
         let expectation = XCTestExpectation(description: "NotificationCenter notified")
         observeNotificationCenter {
             let notifiedDomain = $0.userInfo?["domain"] as? String
-            if (notifiedDomain == domain) {
+            if notifiedDomain == domain {
                 expectation.fulfill()
             }
         }

--- a/Tests/NetworkSubscriberTests.swift
+++ b/Tests/NetworkSubscriberTests.swift
@@ -28,8 +28,6 @@ class NetworkSubscriberTests: XCTestCase {
         let subscriber = SPDiagnose.NetworkSubscriber { receivedDomain in
             if (receivedDomain == domain) {
                 expectation.fulfill()
-            } else {
-                XCTFail("notification intercepted but with a different domain: \(receivedDomain as Any)")
             }
         }
         postNotificationCenter(domain)

--- a/Tests/NetworkSubscriberTests.swift
+++ b/Tests/NetworkSubscriberTests.swift
@@ -26,7 +26,7 @@ class NetworkSubscriberTests: XCTestCase {
         /// if replaced with `_` XCode will release the NetworkSubscriber
         /// causing the test to fail ¯\_(ツ)_/¯
         let subscriber = SPDiagnose.NetworkSubscriber { receivedDomain in
-            if (receivedDomain == domain) {
+            if receivedDomain == domain {
                 expectation.fulfill()
             }
         }

--- a/Tests/SamplingTests.swift
+++ b/Tests/SamplingTests.swift
@@ -1,0 +1,44 @@
+//
+//  SamplingTests.swift
+//  SPDiagnose
+//
+//  Created by Andre Herculano on 8/8/24.
+//
+
+import Foundation
+import XCTest
+@testable import SPDiagnose
+
+class SamplingTests: XCTestCase {
+    override class func setUp() {
+        // resets UserDefaults
+        if let bundleID = Bundle.main.bundleIdentifier {
+            UserDefaults.standard.removePersistentDomain(forName: bundleID)
+        }
+        UserDefaults.standard.synchronize()
+    }
+
+    func testGettingSettingRateWorks() {
+        let storage = UserDefaults.standard
+        let key = SPDiagnose.Sampling.StoreKeys.rate.rawValue
+
+        SPDiagnose.Sampling.shared.setRate(0)
+        assert(storage.integer(forKey: key) == 0)
+        SPDiagnose.Sampling.shared.setRate(10)
+        assert(storage.integer(forKey: key) == 10)
+    }
+
+    func testGettingSettingHitWorks() {
+        let storage = UserDefaults.standard
+        let key = SPDiagnose.Sampling.StoreKeys.hit.rawValue
+
+        SPDiagnose.Sampling.shared.setHit(nil)
+        XCTAssertNil(storage.value(forKey: key))
+        
+        SPDiagnose.Sampling.shared.setHit(false)
+        XCTAssertFalse(storage.bool(forKey: key))
+        
+        SPDiagnose.Sampling.shared.setHit(true)
+        XCTAssertTrue(storage.bool(forKey: key))
+    }
+}

--- a/Tests/iOSExample.xctestplan
+++ b/Tests/iOSExample.xctestplan
@@ -1,0 +1,46 @@
+{
+  "configurations" : [
+    {
+      "id" : "072474F4-6D4C-4A4B-AC32-25F8C671432C",
+      "name" : "Test Scheme Action",
+      "options" : {
+        "maximumTestRepetitions" : 10
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:SPDiagnose.xcodeproj",
+      "identifier" : "827B61CB2B7E696700F2CB68",
+      "name" : "iOSExample"
+    },
+    "testRepetitionMode" : "fixedIterations"
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:SPDiagnose.xcodeproj",
+        "identifier" : "827B61DC2B7E696900F2CB68",
+        "name" : "iOSExampleTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:SPDiagnose.xcodeproj",
+        "identifier" : "827B61E62B7E696900F2CB68",
+        "name" : "SPDiagnoseSDKUITests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:SPDiagnose.xcodeproj",
+        "identifier" : "829EBC3F2BA3417F0063F156",
+        "name" : "SPDiagnoseTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
* after this PR is merged, the SDK will request a sampling rate to Diagnose API when instantiated
* if a user is considered sampled, the SDK will send network/consent events to Diagnose API
* if a user is not sampled, the SDK will behave just as before, but no network call will fired to Diagnose backend.